### PR TITLE
Fix: The API [GET /uiObject/{oid}/getBounds] returns the view's bounds property.

### DIFF
--- a/app/src/main/java/com/dtmilano/android/culebratester2/location/UiObject.kt
+++ b/app/src/main/java/com/dtmilano/android/culebratester2/location/UiObject.kt
@@ -201,7 +201,7 @@ class UiObject {
 
         fun response(): Rect {
             uiObject(oid, objectStore)?.let {
-                val (top, left, right, bottom) = it.bounds
+                val (left, top, right, bottom) = it.bounds
                 return@response Rect(left = left, top = top, right = right, bottom = bottom)
             }
             throw notFound(oid)

--- a/app/src/test/java/com/dtmilano/android/culebratester2/KtorApplicationTest.kt
+++ b/app/src/test/java/com/dtmilano/android/culebratester2/KtorApplicationTest.kt
@@ -235,7 +235,7 @@ class KtorApplicationTest {
             on { className } doReturn MOCK_CLASS_NAME
             on { text } doReturn "Hello Culebra!"
             on { contentDescription } doReturn "Hello Culebra content description"
-            on { bounds } doReturn android.graphics.Rect(100, 100, 600, 900)
+            on { bounds } doReturn android.graphics.Rect(100, 200, 600, 900)
         }
 
         uiObject22 = mock<UiObject2> {
@@ -1029,8 +1029,8 @@ class KtorApplicationTest {
             handleRequest(HttpMethod.Get, "/v2/uiObject/$oid/getBounds").apply {
                 assertEquals(HttpStatusCode.OK, response.status())
                 val rect = jsonResponse<Rect>()
-                assertEquals(100, rect.top)
                 assertEquals(100, rect.left)
+                assertEquals(200, rect.top)
                 assertEquals(600, rect.right)
                 assertEquals(900, rect.bottom)
             }


### PR DESCRIPTION
Expected response:
```
{"bottom":518,"left":925,"right":1009,"top":481}
```

Actual response:
```
{"bottom":518,"left":481,"right":1009,"top":925}
```

The value of the left boundary and the value of the top boundary are swapped.

